### PR TITLE
adjusted loop condition for LeapYearChecker

### DIFF
--- a/src/main/java/LeapYearChecker.java
+++ b/src/main/java/LeapYearChecker.java
@@ -2,7 +2,7 @@ public class LeapYearChecker {
     public static void main(String[] args) {
         int year = 2000;
 
-        if (year % 4 == 0 && year % 100 == 0 || year % 400 == 0) { // Logical operator error
+        if ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)) { // Logical operator error
             System.out.println(year + " is a leap year.");
         } else {
             System.out.println(year + " is not a leap year.");


### PR DESCRIPTION
issue #8 incorrect answer being shown for any given year trial 7
changed if statement condition from:
(year % 4 == 0 && year % 100 == 0 || year % 400 == 0)
to:
((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0))